### PR TITLE
Use pug directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.*/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Use svelte with pug syntax.
 
-*This is an ongoing project, covering the most basic uses. Some other pug features such as include, mixins,... may have not been fully tested*
+*This is an ongoing project, covering the most basic uses. Some other pug features such mixins,... may have not been fully tested.*
 
 ## Install
 ```

--- a/README.md
+++ b/README.md
@@ -116,5 +116,12 @@ p Hello {name}!
 let name = 'World'
 </script>
 ```
+
+## Pug render options
+You can also pass any [options](https://pugjs.org/api/reference.html#options) of `pug.render()`
+```javascript
+pug2svelte(content, { cache: true })
+```
+
 ## License
 [**MIT**](https://github.com/pynnl/pug2svelte/blob/master/LICENSE)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Render a svelte-pug template into html
+ * Render a svelte-pug template into html.
  */
 export default function pug2svelte (
   str: string,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
-let lex = require('pug-lexer')
-let parse = require('pug-parser')
-let { CodeGenerator } = require('pug-code-gen')
-let wrap = require('pug-runtime/wrap')
+let pug = require('pug')
 
 // Check if it's a normal tag, and then fix the svelte
 // block styled attributes if needed. Also check if there
@@ -186,13 +183,12 @@ function preprocess (str) {
 }
 
 // Render a svelte-pug template into html
-let attrs = CodeGenerator.prototype.attrs
 let _html = /^([\s\S]*?<template.*?>)([\s\S]*?)(<\/template>[\s\S]*$)/
-function render (str, { pretty, html } = {}) {
+function render (str, opts = {}) {
   let pre = ''
   let post = ''
 
-  if (html) {
+  if (opts.html) {
     let cap = str.match(_html)
     if (!cap) throw new Error(`Can't find <template lang='pug'>`)
 
@@ -201,13 +197,9 @@ function render (str, { pretty, html } = {}) {
     str = cap[2]
   }
 
-  let gen = new CodeGenerator(parse(lex(preprocess(str))), { pretty })
-  gen.attrs = function () {
-    this.terse = true
-    return attrs.call(this, ...arguments)
-  }
+  str = pug.render(preprocess(str), { ...opts, doctype: 'html' })
 
-  return pre + wrap(gen.compile())() + post
+  return pre + str + post
 }
 
 module.exports = render

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-as-pug",
-  "version": "0.0.2-alpha.2",
+  "version": "0.0.2-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pug2svelte",
-  "version": "0.0.2-alpha.2",
+  "version": "0.0.2-alpha.3",
   "description": "Use svelte with pug syntax",
   "keywords": [
     "preprocess",


### PR DESCRIPTION
- Instead of using lexer, parser,... change to using pug.render() directly.
- Support pug.render() options.